### PR TITLE
Fix mailto link in README

### DIFF
--- a/generators/app/templates/README.MD
+++ b/generators/app/templates/README.MD
@@ -69,4 +69,4 @@ $ npm run lint
 
 ## License
 
-MIT © [<%= props.author.name %>](<%= props.author.email %>)
+MIT © [<%= props.author.name %>](mailto:<%= props.author.email %>)


### PR DESCRIPTION
In my [example module](https://github.com/beeman/angular-sample-module#license) generated by this generator I found that the email address was not correctly linked, this PR fixes it.