### PR TITLE
suggest better default library name

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -2,6 +2,7 @@
 var yeoman = require('yeoman-generator');
 var chalk = require('chalk');
 var yosay = require('yosay');
+var _s = require('underscore.string');
 
 module.exports = yeoman.Base.extend({
   prompting: function () {
@@ -41,8 +42,8 @@ module.exports = yeoman.Base.extend({
         type: 'input',
         name: 'libraryName',
         message: 'Your library name (kebab-case)',
-        default: 'angular-library',
-        store: true
+        default: _s.slugify(this.appname),
+        filter: x => _s.slugify(x)
       },
       {
         type: 'input',

--- a/package.json
+++ b/package.json
@@ -17,8 +17,9 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "yeoman-generator": "^0.22.0",
     "chalk": "^1.1.3",
+    "underscore.string": "^3.3.4",
+    "yeoman-generator": "^0.22.0",
     "yosay": "^1.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
I noticed that the default library name is always `angular-library`. With this PR, it will take the name of the directory and [slugifies](https://github.com/epeli/underscore.string#slugifystring--string) that name. I believe this would be a way better default then what we have today.

If you don't like it, just say so and close the PR. It's just a suggestion, no hard feelings :).