### PR TITLE
Changed template gulpfile to prevent unlinking from npm

### DIFF
--- a/generators/app/templates/gulpfile.js
+++ b/generators/app/templates/gulpfile.js
@@ -208,5 +208,7 @@ gulp.task('default', ['build:watch']);
  * Deletes the specified folder
  */
 function deleteFolders(folders) {
-  return del(folders);
+  var dirToDelete = folders + '/**',
+    dirToIgnore = '!' + folders;
+  return del(dirToDelete, dirToIgnore);
 }


### PR DESCRIPTION
This updates the call in `deleteFolders()` to delete all the children of the directory but not the directory itself so the link with npm is preserved during development.  

[Del documentation indicates that  an entire directory and its children will be deleted](https://www.npmjs.com/package/del#beware) if the directory is not specified in the options parameter. Per  issue #91 deleting the directory will break the link created by `npm  link`.

This does not solve for lack of live-reloading by the Angular CLI, but after running a build and running `ng serve` again you will see the changes picked up in your Angular app. 
 