### PR TITLE
feat(SASS): Allow import scss files from lib or dependencies

### DIFF
--- a/generators/app/templates/_package.json
+++ b/generators/app/templates/_package.json
@@ -51,6 +51,7 @@
     "karma-jasmine": "~1.1.0",
     "karma-jasmine-html-reporter": "^0.2.2",
     "node-sass": "^4.5.2",
+    "node-sass-tilde-importer": "^1.0.0",
     "node-watch": "^0.5.2",
     "protractor": "~5.1.0",
     "rollup": "^0.41.6",

--- a/generators/app/templates/tools/gulp/inline-resources.js
+++ b/generators/app/templates/tools/gulp/inline-resources.js
@@ -6,6 +6,7 @@ const fs = require('fs');
 const path = require('path');
 const glob = require('glob');
 const sass = require('node-sass');
+const tildeImporter = require('node-sass-tilde-importer');
 
 /**
  * Simple Promiseify function that takes a Node API and return a version that supports promises.
@@ -121,7 +122,11 @@ function inlineStyle(content, urlResolver) {
  */
 function buildSass(content, sourceFile) {
   try {
-    const result = sass.renderSync({data: content});
+    const result = sass.renderSync({
+      data: content,
+      file: sourceFile,
+      importer: tildeImporter
+    });
     return result.css.toString()
   } catch (e) {
     console.error('\x1b[41m');


### PR DESCRIPTION
This feature allow the developer to import other SCSS files into the scss component file.

Eg :
From node_modules dependencies : @import '~angular/material/theming';
From other component : @import '../other-component/other-component.component.scss';