### PR TITLE
Feature/jest cleanup

### DIFF
--- a/generators/app/templates/_package_jest.json
+++ b/generators/app/templates/_package_jest.json
@@ -15,11 +15,7 @@
   },
   "jest": {
     "preset": "jest-preset-angular",
-    "setupTestFrameworkScriptFile": "<rootDir>/src/jest.ts",
-    "collectCoverage": true,
-    "coverageDirectory": "coverage",
-    "collectCoverageFrom" : ["src/**/*.ts", "!**/node_modules/**"],
-    "coverageReporters": ["json", "lcov"]
+    "setupTestFrameworkScriptFile": "<rootDir>/src/jest.ts"
   },
   "repository": {
     "type": "git",

--- a/generators/app/templates/src/_tsconfig.spec.json
+++ b/generators/app/templates/src/_tsconfig.spec.json
@@ -1,6 +1,8 @@
 {
   "extends": "./tsconfig.es5.json",
   "compilerOptions": {
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
     "outDir": "../out-tsc/spec",
     "module": "commonjs",
     "target": "es6",


### PR DESCRIPTION
Hi,

i've just noticed that without     "emitDecoratorMetadata": true in the spec files there were some issues regarding testing on jest