### PR TITLE
fix(ngc): remove skipTemplateCodegen as this was suppressing template…

### DIFF
--- a/generators/app/templates/src/_tsconfig.es5.json
+++ b/generators/app/templates/src/_tsconfig.es5.json
@@ -20,7 +20,6 @@
   "angularCompilerOptions": {
     "annotateForClosureCompiler": true,
     "strictMetadataEmit": true,
-    "skipTemplateCodegen": true,
     "flatModuleOutFile": "<%= props.libraryName.kebabCase %>.js",
     "flatModuleId": "<%= props.libraryName.kebabCase %>"
   },


### PR DESCRIPTION
… errors

Errors and warnings within the html template are not emitted when this flag is set to false.

Such as using template instead of ng-template or referencing a non existing variable