### PR TITLE
#207 - Fixed issue with '@angular/compiler-cli' renaming certain typescript imports

### DIFF
--- a/generators/app/templates/src/_tsconfig.es5.json
+++ b/generators/app/templates/src/_tsconfig.es5.json
@@ -18,7 +18,7 @@
     "types": []
   },
   "angularCompilerOptions": {
-    "annotateForClosureCompiler": true,
+    "annotateForClosureCompiler": false,
     "strictMetadataEmit": true,
     "skipTemplateCodegen": true,
     "flatModuleOutFile": "<%= props.libraryName.kebabCase %>.js",


### PR DESCRIPTION
Fix for jvandemo#207 issue with renaming of certain Angular imports by `@angular/compiler-cli`, as proposed in following comment angular/angular#19026

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jvandemo/generator-angular2-library/213)
<!-- Reviewable:end -->
