### PR TITLE
fix mkdir error

### DIFF
--- a/generators/app/templates/gulpfile.js
+++ b/generators/app/templates/gulpfile.js
@@ -51,7 +51,7 @@ gulp.task('inline-resources', function () {
  *    As of Angular 5, ngc accepts an array and no longer returns a promise.
  */
 gulp.task('ngc', function () {
-  ngc([ '--project', `${tmpFolder}/tsconfig.es5.json` ]);
+  ngc(['--project', `${tmpFolder}/tsconfig.es5.json`]);
   return Promise.resolve()
 });
 
@@ -61,7 +61,7 @@ gulp.task('ngc', function () {
  */
 gulp.task('rollup:fesm', function () {
   return gulp.src(`${buildFolder}/**/*.js`)
-  // transform the files here.
+    // transform the files here.
     .pipe(rollup({
 
       // Bundle's entry point
@@ -94,7 +94,7 @@ gulp.task('rollup:fesm', function () {
  */
 gulp.task('rollup:umd', function () {
   return gulp.src(`${buildFolder}/**/*.js`)
-  // transform the files here.
+    // transform the files here.
     .pipe(rollup({
 
       // Bundle's entry point
@@ -209,10 +209,18 @@ gulp.task('watch', function () {
   gulp.watch(`${srcFolder}/**/*`, ['compile']);
 });
 
-gulp.task('clean', ['clean:dist', 'clean:tmp', 'clean:build']);
+gulp.task('clean', function (callback) {
+  runSequence('clean:dist', 'clean:tmp', 'clean:build', callback);
+});
 
-gulp.task('build', ['clean', 'compile']);
-gulp.task('build:watch', ['build', 'watch']);
+gulp.task('build', function (callback) {
+  runSequence('clean', 'compile', callback);
+});
+
+gulp.task('build:watch', function (callback) {
+  runSequence('build', 'watch', callback);
+});
+
 gulp.task('default', ['build:watch']);
 
 /**


### PR DESCRIPTION
`gulp.task("X",["A","B"]) `
run A and B simultaneously. in the case of build task, if you haven't chance, the "build" task mkdir temp folder before the clean and throw an error.
with runSequence, B is run after A.
