### PR TITLE
fix(templates): Added a missing boolean to activate the semicolon tslint rule.

### DIFF
--- a/generators/app/templates/_tslint.json
+++ b/generators/app/templates/_tslint.json
@@ -64,6 +64,7 @@
     ],
     "radix": true,
     "semicolon": [
+      true,
       "always"
     ],
     "triple-equals": [


### PR DESCRIPTION
The tslint.json template was missing a "true" to make the semicolon rule actually activate.